### PR TITLE
docs: add unshared private label (:Z) to volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ podman run -p 8080:8080 -ti ghcr.io/xkcd-2347/guac:latest gql-server --gql-debug
 Ingest test SBOMs:
 
 ```
-podman run --net=host -v $PWD/data/files:/data -ti ghcr.io/xkcd-2347/guac:latest files /data
+podman run --net=host -v $PWD/data/files:/data:Z -ti ghcr.io/xkcd-2347/guac:latest files /data
 ```
 
 Run certifier:


### PR DESCRIPTION
This commit adds the :Z option to the volume mount for the ingest of sboms command.

The motivation for addings this is that I ran into the following error without this option:
```console
$  podman run --net=host -v $PWD/data/files:/data -ti localhost/my-guac files /data
{"level":"error","ts":1682588821.0231836,"caller":"cmd/files.go:173","msg":"collector ended with error: error walking path: /data, err: path: /data is invalid","stacktrace":"github.com/guacsec/guac/cmd/guacone/cmd.glob..func5.2\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/cmd/files.go:173\ngithub.com/guacsec/guac/pkg/handler/collector.Collect\n\t/home/danielbevenius/work/security/seedwing/guac/pkg/handler/collector/collector.go:92\ngithub.com/guacsec/guac/cmd/guacone/cmd.glob..func5\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/cmd/files.go:176\ngithub.com/spf13/cobra.(*Command).execute\n\t/home/danielbevenius/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/home/danielbevenius/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044\ngithub.com/spf13/cobra.(*Command).Execute\n\t/home/danielbevenius/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968\ngithub.com/guacsec/guac/cmd/guacone/cmd.Execute\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/cmd/root.go:124\nmain.main\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/main.go:23\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
{"level":"fatal","ts":1682588821.0232587,"caller":"cmd/files.go:177","msg":"error walking path: /data, err: path: /data is invalid","stacktrace":"github.com/guacsec/guac/cmd/guacone/cmd.glob..func5\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/cmd/files.go:177\ngithub.com/spf13/cobra.(*Command).execute\n\t/home/danielbevenius/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/home/danielbevenius/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044\ngithub.com/spf13/cobra.(*Command).Execute\n\t/home/danielbevenius/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968\ngithub.com/guacsec/guac/cmd/guacone/cmd.Execute\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/cmd/root.go:124\nmain.main\n\t/home/danielbevenius/work/security/seedwing/guac/cmd/guacone/main.go:23\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```