### PR TITLE
README's instructions maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo run -- run -p 8081
 You can also run the API server using a container:
 
 ```shell
-podman run -p 8080:8080 -ti ghcr.io/xkcd-2347/trust-api:latest run -p 8081 
+podman run --net=host -ti ghcr.io/xkcd-2347/trust-api:latest run -p 8081
 ```
 
 ### Using Snyk
@@ -79,7 +79,7 @@ curl -s "http://localhost:8081/api/vulnerability?cve=cve-2023-0286" | jq
 #### Quarkus Examples
 
 ```shell
-curl --json '["pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final"]' http://localhost:8081/api/package | jq
+curl --json '["pkg:maven/io.quarkus/quarkus-vertx@2.16.2.Final?type=jar"]' http://localhost:8081/api/package | jq
 ```
 
 ```shell
@@ -91,5 +91,5 @@ curl --json '["pkg:maven/io.vertx/vertx-web@4.3.7"]' http://localhost:8081/api/p
 ```
 
 ```shell
-curl --json '["pkg:maven/io.vertx/vertx-web@4.3.7"]' http://localhost:8081/api/package/versions | jq
+curl --json '["pkg:maven/io.vertx/vertx-web"]' http://localhost:8081/api/package/search | jq
 ```


### PR DESCRIPTION
- port `8080` mapping for `trust-api` container has a conflict with previously started `guac` container
- changed version for `quarkus-vert` package
- `versions` endpoint looks like migrated to be `search` 